### PR TITLE
add TrimSuffix to the function map

### DIFF
--- a/golink.go
+++ b/golink.go
@@ -353,6 +353,7 @@ type expandEnv struct {
 var expandFuncMap = texttemplate.FuncMap{
 	"PathEscape":  url.PathEscape,
 	"QueryEscape": url.QueryEscape,
+	"TrimSuffix": strings.TrimSuffix,
 }
 
 // expandLink returns the expanded long URL to redirect to, executing any


### PR DESCRIPTION
Adds strings.TrimSuffix to the function map, enabling it to be used in URL definitions.